### PR TITLE
Cmd client setup to use `yargs` with bookmark test case

### DIFF
--- a/clients/cmdline/cli.js
+++ b/clients/cmdline/cli.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+require("yargs/yargs")(process.argv.slice(2))
+  // .parserConfiguration()
+  .commandDir("cmds", {
+    // TODO: convert ts to js for real use
+		extensions: process.env.NODE_ENV === "production" ? ["js"] : ["js", "ts"],
+    visit: (commandModule) => {
+      return commandModule.default;
+    },
+  })
+  .demandCommand()
+  .help().argv;

--- a/clients/cmdline/cmds/bookmark.ts
+++ b/clients/cmdline/cmds/bookmark.ts
@@ -1,0 +1,16 @@
+import * as yargs from "yargs";
+import { commandDirOptions } from "../utils/helpers";
+
+export default {
+  command: "bookmark <command>",
+  aliases: ["bm"],
+  describe: "Add, remove or list new bookmarks or interesting reads",
+  builder: (yargs: yargs.Argv) => {
+    return yargs
+      .usage("Usage: $0 bm <command> [options]")
+      .commandDir("bookmark", commandDirOptions)
+      .demandCommand()
+      .version(false);
+  },
+  handler: (argv) => {},
+} as yargs.CommandModule;

--- a/clients/cmdline/cmds/bookmark/add.ts
+++ b/clients/cmdline/cmds/bookmark/add.ts
@@ -1,0 +1,33 @@
+import * as yargs from "yargs";
+import { makePost } from "../../utils/helpers";
+
+export default {
+  command: "add <url>",
+  aliases: [],
+  describe: "Add a bookmark for <url>",
+  builder: (yargs: yargs.Argv) => {
+    return yargs
+      .usage("Usage: $0 bm add <url> [options]")
+      .options("t", {
+        alias: "tag",
+        describe: "Add a tag",
+        default: "default",
+      })
+      .options("n", {
+        alias: "name",
+        describe: "Add a name to refer as",
+      })
+      .version(false);
+  },
+  handler: async (argv) => {
+    // TODO: validation? or server side?
+    const res = await makePost("/bookmark/add", {
+      url: argv.url,
+      name: argv.name,
+      tag: argv.tag,
+    });
+    // TODO: error handling or dont need to?
+    // TODO: success response or dont need to?
+    console.log(res);
+  },
+} as yargs.CommandModule;

--- a/clients/cmdline/cmds/bookmark/list.ts
+++ b/clients/cmdline/cmds/bookmark/list.ts
@@ -1,0 +1,35 @@
+import * as yargs from "yargs";
+import { makeGet } from "../../utils/helpers";
+
+export default {
+  command: "ls",
+  aliases: ["list"],
+  describe: "List all available bookmarks",
+  builder: (yargs: yargs.Argv) => {
+    return yargs
+      .usage("Usage: $0 bm ls [options]")
+      .options("t", {
+        alias: "tag",
+        describe: "Add a tag",
+        default: "default",
+      })
+      .options("s", {
+        alias: "skip",
+        describe: "Amount in list to skip for pagination",
+      })
+      .options("q", {
+        alias: "take",
+        describe: "Amount in list to display",
+        default: 20, // TODO: shared directory for stuff like this
+      })
+      .version(false);
+  },
+  handler: async (argv) => {
+    const res = await makeGet("/bookmark/list", {
+      tag: argv.tag,
+      skip: argv.skip,
+      take: argv.take,
+    });
+    console.log(res);
+  },
+} as yargs.CommandModule;

--- a/clients/cmdline/utils/helpers.ts
+++ b/clients/cmdline/utils/helpers.ts
@@ -1,0 +1,53 @@
+import bent from "bent";
+
+export const commandDirOptions = {
+  // TODO: convert ts to js for real use - NOTE: this is also the case inside root level cli.js
+  extensions: ["js", "ts"],
+  visit: (commandModule: any) => {
+    return commandModule.default;
+  },
+};
+
+// FIXME: env vars !!!
+
+export const authenticateAndGetJwt = () => {
+  // TODO: login once, then store somewhere on disk?
+  const stub =
+    "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjMsInVzZXJuYW1lIjoidGVzdCIsImVtYWlsIjoiYXdlc29tZUB0ZXN0LmNvbSJ9.jeSL8I8MgkAhWtqFPkU6hLTuWJLkIBJDQXZg3lbSZP8d0bjC8z2R0rbxwq1lM-JesdD54eG2Vsj4d2uLAWlgbA";
+  const token = stub;
+  return token;
+};
+
+export const makePost = async (relativeUrl: string, body: any) => {
+  const token = authenticateAndGetJwt();
+  const headers = {
+    authorization: `Bearer ${token}`,
+  };
+  const post = bent("http://localhost:8080", "POST", "json", 200);
+  console.log(relativeUrl);
+  return post(relativeUrl, body, headers);
+};
+
+interface BentQuerystring {
+  [key: string]: string | number | unknown;
+}
+
+export const makeGet = async (
+  relativeUrl: string,
+  querystringItems: BentQuerystring
+) => {
+  const token = authenticateAndGetJwt();
+  const headers = {
+    authorization: `Bearer ${token}`,
+  };
+  const querystring = Object.entries(querystringItems)
+    .map(([key, value]) => (value ? `${key}=${value}` : undefined))
+    .filter((x) => !!x)
+    .join("&");
+  const fullQuerystring = querystring ? `?${querystring}` : "";
+  const fullUrl = relativeUrl + fullQuerystring;
+
+  const get = bent("http://localhost:8080", "GET", "json", 200);
+  console.log(fullUrl);
+  return get(fullUrl, undefined, headers);
+};

--- a/package.json
+++ b/package.json
@@ -11,13 +11,16 @@
     "server": "nodemon --watch \"server/**\" --ext \"ts,json\" --exec \"yarn ts-node -r make-promises-safe ./server/index.ts\"",
     "prisma:generate": "prisma generate --schema ./server/prisma/schema.prisma",
     "prisma:migrate:save": "prisma migrate save --experimental --schema=./server/prisma/schema.prisma",
-    "prisma:migrate:all": "prisma migrate up --experimental"
+    "prisma:migrate:all": "prisma migrate up --experimental",
+    "cli": "ts-node ./clients/cmdline/cli.js"
   },
   "devDependencies": {
     "@prisma/cli": "^2.8.1",
     "@types/bcrypt": "^3.0.0",
+    "@types/bent": "^7.3.1",
     "@types/jsonwebtoken": "^8.5.0",
     "@types/node": "^14.11.8",
+    "@types/yargs": "^15.0.9",
     "nodemon": "^2.0.4",
     "ts-node": "^9.0.0",
     "typescript": "^4.0.3"
@@ -25,12 +28,14 @@
   "dependencies": {
     "@prisma/client": "^2.8.1",
     "bcrypt": "^5.0.0",
+    "bent": "^7.3.12",
     "dotenv": "^8.2.0",
     "envalid": "^6.0.2",
     "fastify": "^3.5.1",
     "jsonwebtoken": "^8.5.1",
     "make-promises-safe": "^5.1.0",
-    "utility-types": "^3.10.0"
+    "utility-types": "^3.10.0",
+    "yargs": "^16.1.0"
   },
   "prisma": {
     "schema": "server/prisma/schema.prisma"

--- a/server/api/bookmark/bookmark.ts
+++ b/server/api/bookmark/bookmark.ts
@@ -39,12 +39,12 @@ const registerBookmarkRoutes: RegisterFunctionType = (server, opts, done) => {
           isActive: true,
         },
         where: {
-					// TODO: consider semantics of whether we should upsert and make active (but return with
-					// incorrect name/tag) or if we should just disallow altogether
-          url: request.body.url, 
+          // TODO: consider semantics of whether we should upsert and make active (but return with
+          // incorrect name/tag) or if we should just disallow altogether
+          url: request.body.url,
         },
-			});
-			
+      });
+
       return reply.send(bm);
     }
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -31,6 +31,13 @@
   resolved "https://registry.yarnpkg.com/@types/bcrypt/-/bcrypt-3.0.0.tgz#851489a9065a067cb7f3c9cbe4ce9bed8bba0876"
   integrity sha512-nohgNyv+1ViVcubKBh0+XiNJ3dO8nYu///9aJ4cgSqv70gBL+94SNy/iC2NLzKPT2Zt/QavrOkBVbZRLZmw6NQ==
 
+"@types/bent@^7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@types/bent/-/bent-7.3.1.tgz#e59e9144058da1843c00b8fcc3c5b3ed7bfab9e6"
+  integrity sha512-76ieb6NdaxXAURJwTXaFYovU7lXB2cO03vMMCDlfTb12Uw7jgEBdAABBMvsm/SIB6LavDofvFXYDhiU/qAySDg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/jsonwebtoken@^8.5.0":
   version "8.5.0"
   resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-8.5.0.tgz#2531d5e300803aa63279b232c014acf780c981c5"
@@ -42,6 +49,18 @@
   version "14.11.8"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.11.8.tgz#fe2012f2355e4ce08bca44aeb3abbb21cf88d33f"
   integrity sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw==
+
+"@types/yargs-parser@*":
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
+  integrity sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==
+
+"@types/yargs@^15.0.9":
+  version "15.0.9"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.9.tgz#524cd7998fe810cdb02f26101b699cccd156ff19"
+  integrity sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==
+  dependencies:
+    "@types/yargs-parser" "*"
 
 abbrev@1:
   version "1.1.1"
@@ -90,7 +109,7 @@ ansi-regex@^5.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
 
-ansi-styles@^4.1.0:
+ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
@@ -156,6 +175,15 @@ bcrypt@^5.0.0:
     node-addon-api "^3.0.0"
     node-pre-gyp "0.15.0"
 
+bent@^7.3.12:
+  version "7.3.12"
+  resolved "https://registry.yarnpkg.com/bent/-/bent-7.3.12.tgz#e0a2775d4425e7674c64b78b242af4f49da6b035"
+  integrity sha512-T3yrKnVGB63zRuoco/7Ybl7BwwGZR0lceoVG5XmQyMIH9s19SV5m+a8qam4if0zQuAmOQTyPTPmsQBdAorGK3w==
+  dependencies:
+    bytesish "^0.4.1"
+    caseless "~0.12.0"
+    is-stream "^2.0.0"
+
 binary-extensions@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.1.0.tgz#30fa40c9e7fe07dbc895678cd287024dea241dd9"
@@ -200,6 +228,11 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
+bytesish@^0.4.1:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/bytesish/-/bytesish-0.4.4.tgz#f3b535a0f1153747427aee27256748cff92347e6"
+  integrity sha512-i4uu6M4zuMUiyfZN4RU2+i9+peJh//pXhd9x1oSe1LBkZ3LEbCoygu8W0bXTukU1Jme2txKuotpCZRaC3FLxcQ==
+
 cacheable-request@^6.0.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-6.1.0.tgz#20ffb8bd162ba4be11e9567d823db651052ca912"
@@ -217,6 +250,11 @@ camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
+
+caseless@~0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
+  integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
 chalk@^3.0.0:
   version "3.0.0"
@@ -255,6 +293,15 @@ cli-boxes@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-2.2.1.tgz#ddd5035d25094fce220e9cab40a45840a440318f"
   integrity sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==
+
+cliui@^7.0.2:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.3.tgz#ef180f26c8d9bff3927ee52428bfec2090427981"
+  integrity sha512-Gj3QHTkVMPKqwP3f7B4KPkBZRMR9r4rfi5bXFpg1a+Svvj8l7q5CnkBkVQzfxT5DFSsGk2+PascOgL0JYkL2kw==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
 
 clone-response@^1.0.2:
   version "1.0.2"
@@ -426,6 +473,11 @@ envalid@^6.0.2:
     meant "^1.0.1"
     validator "^13.0.0"
 
+escalade@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
+  integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
+
 escape-goat@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/escape-goat/-/escape-goat-2.1.1.tgz#1b2dc77003676c457ec760b2dc68edb648188675"
@@ -567,6 +619,11 @@ gauge@~2.7.3:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
+
+get-caller-file@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
+  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
 get-stream@^4.1.0:
   version "4.1.0"
@@ -777,6 +834,11 @@ is-path-inside@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.2.tgz#f5220fc82a3e233757291dddc9c5877f2a1f3017"
   integrity sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==
+
+is-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
+  integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
 
 is-typedarray@^1.0.0:
   version "1.0.0"
@@ -1301,6 +1363,11 @@ registry-url@^5.0.0:
   dependencies:
     rc "^1.2.8"
 
+require-directory@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
+  integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
+
 responselike@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/responselike/-/responselike-1.0.2.tgz#918720ef3b631c5642be068f15ade5a46f4ba1e7"
@@ -1456,7 +1523,7 @@ string-width@^3.0.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
-string-width@^4.0.0, string-width@^4.1.0:
+string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
   integrity sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
@@ -1672,6 +1739,15 @@ widest-line@^3.1.0:
   dependencies:
     string-width "^4.0.0"
 
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -1692,10 +1768,33 @@ xdg-basedir@^4.0.0:
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz#4bc8d9984403696225ef83a1573cbbcb4e79db13"
   integrity sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==
 
+y18n@^5.0.2:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.4.tgz#0ab2db89dd5873b5ec4682d8e703e833373ea897"
+  integrity sha512-deLOfD+RvFgrpAmSZgfGdWYE+OKyHcVHaRQ7NphG/63scpRvTHHeQMAxGGvaLVGJ+HYVcCXlzcTK0ZehFf+eHQ==
+
 yallist@^3.0.0, yallist@^3.0.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yargs-parser@^20.2.2:
+  version "20.2.3"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.3.tgz#92419ba867b858c868acf8bae9bf74af0dd0ce26"
+  integrity sha512-emOFRT9WVHw03QSvN5qor9QQT9+sw5vwxfYweivSMHTcAXPefwVae2FjO7JJjj8hCE4CzPOPeFM83VwT29HCww==
+
+yargs@^16.1.0:
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.1.0.tgz#fc333fe4791660eace5a894b39d42f851cd48f2a"
+  integrity sha512-upWFJOmDdHN0syLuESuvXDmrRcWd1QafJolHskzaw79uZa7/x53gxQKiR07W59GWY1tFhhU/Th9DrtSfpS782g==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.2"
+    yargs-parser "^20.2.2"
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
- Add `yargs` as cmdline parser
- Add basic bookmark commands to test `yargs`
- Create helpers to utilise `bent` as http library, there still exists
  some todos and fixmes to better improve cmd experience
- Fix whitespacing on server bookmarks